### PR TITLE
以站点名获取网站标题

### DIFF
--- a/views/shared/layout.html
+++ b/views/shared/layout.html
@@ -12,7 +12,7 @@
     <link href="/libs/font-awesome/css/font-awesome.min.css" rel="stylesheet">
     <link href="/stylesheets/share.css" rel="stylesheet">
     <link href="/stylesheets/animate-custom.css" rel="stylesheet">
-    <title></title>
+    <title>@config.SiteName</title>
 </head>
 <body class="fuelux">
 @if(model.isRoot) {


### PR DESCRIPTION
不加这一项的话，网站标题一直为空或者默认。加入这句后，网站标题可以后台配置