### PR TITLE
在文章页的时候，将网站标题设置为，文章标题

### DIFF
--- a/views/blog/article.html
+++ b/views/blog/article.html
@@ -98,6 +98,7 @@
 <script type="text/javascript" src="/javascripts/highlight.pack.js" charset="utf-8"></script>
 <script type="text/javascript" src="/javascripts/article.js" charset="utf-8"></script>
 <script>
+    document.title = '@post.Title';
     var expandMenu = '@config.ExpandMenu';
     var logoPath = "@config.LogoPath";
     var jiathis_config = {


### PR DESCRIPTION
因为每次打开一篇文章，tab页都是千篇一律的网站标题，需要一个个点进去才知道文章内容。
加入此句，可以向文章标题设置为网站标题，方便查看