### PR TITLE
解决热门文章列表出现草稿文章

### DIFF
--- a/server/proxy/index.ts
+++ b/server/proxy/index.ts
@@ -96,7 +96,11 @@ export async function getPosts (params) {
 }
 
 export async function getPopArticles () {
-  const articles = await Post.find({}, '-content', {
+  const conditions: any = {
+    isDraft: false,
+    isActive: true
+  };
+  const articles = await Post.find(conditions, '-content', {
     sort: '-viewCount',
     limit: 7
   })


### PR DESCRIPTION
热门文章查询时忘记筛选草稿和有效状态 emmm