### PR TITLE
修复了alias尾部出现空格链接点击与右侧标题导航404问题(发布文章与保存修改时自动删除首尾空格)

### DIFF
--- a/server/proxy/admin.ts
+++ b/server/proxy/admin.ts
@@ -175,6 +175,9 @@ export async function getArticle (uid) {
 
 export async function newArticle (params) {
   const now = new Date();
+
+  //删除alias收尾空格，确保尾部不会出现空格(会造成链接点击进入与右侧导航出现404)
+  params.alias = params.alias.trim();
   const doc: IPost = {
     createTime: now,
     modifyTime: now,
@@ -193,6 +196,9 @@ export async function newArticle (params) {
 export async function editArticle (query, params: IPost) {
   const now = new Date();
   params.modifyTime = now;
+
+  //删除alias收尾空格，确保尾部不会出现空格(会造成链接点击进入与右侧导航出现404)
+  params.alias = params.alias.trim();
 
   // 草稿状态->已发布，要修改publishTime字段
   if (query.pubtype === 'publish') {


### PR DESCRIPTION
今晚使用时手残alias最后打了个空格，然后右侧导航点击404。进入文章刷新也是404,。最后检查数据库发现alias多了空格，所以想自动删除收尾空格，以确保不会出现此类问题。