### PR TITLE
alias尾部出现空格时 右侧标题点击与刷新页面会出现404

### DIFF
--- a/server/proxy/admin.ts
+++ b/server/proxy/admin.ts
@@ -196,9 +196,11 @@ export async function newArticle (params) {
 export async function editArticle (query, params: IPost) {
   const now = new Date();
   params.modifyTime = now;
-
+  
   //删除alias收尾空格，确保尾部不会出现空格(会造成链接点击进入与右侧导航出现404)
-  params.alias = params.alias.trim();
+  if(params.alias){
+    params.alias = params.alias.trim();
+  }
 
   // 草稿状态->已发布，要修改publishTime字段
   if (query.pubtype === 'publish') {

--- a/server/proxy/admin.ts
+++ b/server/proxy/admin.ts
@@ -175,6 +175,9 @@ export async function getArticle (uid) {
 
 export async function newArticle (params) {
   const now = new Date();
+
+  //删除alias收尾空格，确保尾部不会出现空格(会造成链接点击进入与右侧导航出现404)
+  params.alias = params.alias.trim();
   const doc: IPost = {
     createTime: now,
     modifyTime: now,
@@ -193,6 +196,9 @@ export async function newArticle (params) {
 export async function editArticle (query, params: IPost) {
   const now = new Date();
   params.modifyTime = now;
+
+  //删除alias收尾空格，确保尾部不会出现空格(会造成链接点击进入与右侧导航出现404)
+  params.alias = params.alias.trim();
 
   // 草稿状态->已发布，要修改publishTime字段
   if (query.pubtype === 'publish') {


### PR DESCRIPTION
使用的trim = = 删除首尾空格，保证手残的情况下不会出现问题